### PR TITLE
Add nonroot user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,6 @@ FROM gcr.io/distroless/static-debian12
 EXPOSE 3100
 
 COPY --from=builder /tmp/lokxy /usr/local/bin/lokxy
+USER lokxyuser
 
 CMD ["/usr/local/bin/lokxy"]


### PR DESCRIPTION
Distroless images have 3 users by default as far as I am aware:

```sh
docker run --rm --entrypoint cat gcr.io/distroless/static-debian12:debug /etc/passwd                               
root:x:0:0:root:/root:/sbin/nologin
nobody:x:65534:65534:nobody:/nonexistent:/sbin/nologin
nonroot:x:65532:65532:nonroot:/home/nonroot:/sbin/nologin
```

To make sure the user isn't ROOT you can either choose nonroot/nobody or create your own specific user.