### PR TITLE
fix - lint errors

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,8 +41,17 @@ func main() {
 	})
 
 	// Start the HTTP server
-	level.Info(logger).Log("msg", "Starting lokxy", "addr", bindAddr)
+	if err := level.Info(logger).Log("msg", "Starting lokxy", "addr", bindAddr); err != nil {
+		if logErr := level.Error(logger).Log("msg", "Failed to log start message", "err", err); logErr != nil {
+			fmt.Println("Logging error:", logErr)
+		}
+	}
+
 	if err := http.ListenAndServe(*bindAddr, nil); err != nil {
-		level.Info(logger).Log("msg", "Serving lokxy failed", "err", err)
+		if err := level.Info(logger).Log("msg", "Serving lokxy failed", "err", err); err != nil {
+			if logErr := level.Error(logger).Log("msg", "Failed to log serve failure", "err", err); logErr != nil {
+				fmt.Println("Logging error:", logErr)
+			}
+		}
 	}
 }

--- a/pkg/o11y/logging/logging_test.go
+++ b/pkg/o11y/logging/logging_test.go
@@ -1,10 +1,8 @@
 package logging
 
 import (
-	"bytes"
 	"testing"
 
-	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 
 	"github.com/paulojmdias/lokxy/pkg/config"
@@ -40,29 +38,23 @@ func TestConfigureLogger(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var buf bytes.Buffer
+			logger := ConfigureLogger(tt.config)
 
 			// Check logger level
-			logger := ConfigureLogger(tt.config)
 			if logger == nil {
 				t.Fatalf("Expected logger to be configured, got nil")
-			}
-			logger = log.NewSyncLogger(log.NewLogfmtLogger(&buf))
-			if tt.config.Format == "json" {
-				logger = log.NewSyncLogger(log.NewJSONLogger(&buf))
-			}
-
-			err := logger.Log("key", "value")
-			if err != nil {
-				t.Errorf("Error while logging: %v", err)
 			}
 
 			// Check logger format
 			// Note: This is a simplified check. In a real-world scenario, you might need to capture and parse log output.
 			if tt.config.Format == "json" {
-				t.Errorf("Expected logger to be in json format, got %T", logger)
+				if logger == nil {
+					t.Errorf("Expected logger to be initialized, got nil")
+				}
 			} else if tt.config.Format == "logfmt" {
-				t.Errorf("Expected logger to be in logfmt format, got %T", logger)
+				if logger == nil {
+					t.Errorf("Expected logger to be initialized, got nil")
+				}
 			}
 		})
 	}

--- a/pkg/proxy/handler/labels.go
+++ b/pkg/proxy/handler/labels.go
@@ -14,16 +14,16 @@ func HandleLokiLabels(w http.ResponseWriter, results <-chan *http.Response, logg
 	mergedLabelValues := make(map[string]struct{})
 
 	for resp := range results {
-		defer resp.Body.Close()
-
 		bodyBytes, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
 		if err != nil {
-			level.Error(logger).Log("msg", "Failed to read response body", "err", err)
+			_ = level.Error(logger).Log("msg", "Failed to read response body", "err", err)
 			continue
 		}
 
 		// Log the raw body for debugging
-		level.Debug(logger).Log("msg", "Received body for label values", "body", string(bodyBytes))
+		_ = level.Debug(logger).Log("msg", "Received body for label values", "body", string(bodyBytes))
 
 		// Unmarshal into a struct that matches the actual response format
 		var labelResponse struct {
@@ -32,7 +32,7 @@ func HandleLokiLabels(w http.ResponseWriter, results <-chan *http.Response, logg
 		}
 
 		if err := json.Unmarshal(bodyBytes, &labelResponse); err != nil {
-			level.Error(logger).Log("msg", "Failed to unmarshal label values response", "err", err)
+			_ = level.Error(logger).Log("msg", "Failed to unmarshal label values response", "err", err)
 			continue
 		}
 
@@ -57,7 +57,8 @@ func HandleLokiLabels(w http.ResponseWriter, results <-chan *http.Response, logg
 		"data":   finalLabelValues,
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(finalResponse); err != nil {
-		level.Error(logger).Log("msg", "Failed to encode final response for label values", "err", err)
+		_ = level.Error(logger).Log("msg", "Failed to encode final response for label values", "err", err)
 	}
 }

--- a/pkg/proxy/handler/series.go
+++ b/pkg/proxy/handler/series.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -18,7 +19,9 @@ func HandleLokiSeries(w http.ResponseWriter, results <-chan *http.Response, logg
 		// Read the entire body
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
-			level.Error(logger).Log("msg", "Failed to read response body", "err", err)
+			if logErr := level.Error(logger).Log("msg", "Failed to read response body", "err", err); logErr != nil {
+				fmt.Println("Error logging failure:", logErr)
+			}
 			continue
 		}
 
@@ -28,7 +31,9 @@ func HandleLokiSeries(w http.ResponseWriter, results <-chan *http.Response, logg
 			Status string              `json:"status"`
 		}
 		if err := json.Unmarshal(bodyBytes, &queryResult); err != nil {
-			level.Error(logger).Log("msg", "Failed to unmarshal Loki series response", "err", err)
+			if logErr := level.Error(logger).Log("msg", "Failed to unmarshal Loki series response", "err", err); logErr != nil {
+				fmt.Println("Error logging failure:", logErr)
+			}
 			continue
 		}
 
@@ -37,7 +42,7 @@ func HandleLokiSeries(w http.ResponseWriter, results <-chan *http.Response, logg
 	}
 
 	// Log the merged series for debugging purposes
-	level.Debug(logger).Log("msg", "Merged series", "series", mergedSeries)
+	_ = level.Debug(logger).Log("msg", "Merged series", "series", mergedSeries)
 
 	// Prepare final response
 	finalResponse := map[string]interface{}{
@@ -46,9 +51,11 @@ func HandleLokiSeries(w http.ResponseWriter, results <-chan *http.Response, logg
 	}
 
 	// Log the answer series for debugging purposes
-	level.Debug(logger).Log("msg", "Grafana Answer", "series", finalResponse)
+	_ = level.Debug(logger).Log("msg", "Grafana Answer", "series", finalResponse)
 
 	if err := json.NewEncoder(w).Encode(finalResponse); err != nil {
-		level.Error(logger).Log("msg", "Failed to encode final response", "err", err)
+		if logErr := level.Error(logger).Log("msg", "Failed to encode final response", "err", err); logErr != nil {
+			fmt.Println("Error logging failure:", logErr)
+		}
 	}
 }

--- a/pkg/proxy/handler/stats.go
+++ b/pkg/proxy/handler/stats.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -18,7 +19,9 @@ func HandleLokiStats(w http.ResponseWriter, results <-chan *http.Response, logge
 		// Read the entire body
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
-			level.Error(logger).Log("msg", "Failed to read response body", "err", err)
+			if logErr := level.Error(logger).Log("msg", "Failed to read response body", "err", err); logErr != nil {
+				fmt.Println("Error logging failure:", logErr)
+			}
 			continue
 		}
 
@@ -30,7 +33,9 @@ func HandleLokiStats(w http.ResponseWriter, results <-chan *http.Response, logge
 			Entries int `json:"entries"`
 		}
 		if err := json.Unmarshal(bodyBytes, &statsResponse); err != nil {
-			level.Error(logger).Log("msg", "Failed to unmarshal stats response", "err", err)
+			if logErr := level.Error(logger).Log("msg", "Failed to unmarshal stats response", "err", err); logErr != nil {
+				fmt.Println("Error logging failure:", logErr)
+			}
 			continue
 		}
 
@@ -51,6 +56,8 @@ func HandleLokiStats(w http.ResponseWriter, results <-chan *http.Response, logge
 
 	// Send the merged stats response back to the client
 	if err := json.NewEncoder(w).Encode(finalStatsResponse); err != nil {
-		level.Error(logger).Log("msg", "Failed to encode final response", "err", err)
+		if logErr := level.Error(logger).Log("msg", "Failed to encode final response", "err", err); logErr != nil {
+			fmt.Println("Error logging failure:", logErr)
+		}
 	}
 }


### PR DESCRIPTION
Fix lint issues

```shell
#TODO
pkg/proxy/handler/query.go:25:3: SA9001: defers in this range loop won't run unless the channel gets closed (staticcheck)
		defer resp.Body.Close()
		^
pkg/proxy/handler/series.go:17:3: SA9001: defers in this range loop won't run unless the channel gets closed (staticcheck)
		defer resp.Body.Close()
		^
pkg/proxy/handler/stats.go:17:3: SA9001: defers in this range loop won't run unless the channel gets closed (staticcheck)
		defer resp.Body.Close()
		^
pkg/proxy/proxy.go:69:3: ineffectual assignment to dialTimeout (ineffassign)
		dialTimeout = 200 * time.Millisecond // Default timeout
```