### PR TITLE
ci: rename format to formats in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,7 +16,8 @@ metadata:
 report_sizes: true
 
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     files:
       - LICENSE
 


### PR DESCRIPTION
```
  • setting defaults
    • DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
```