### PR TITLE
feat: Add support for /loki/api/v1/detected_labels

### DIFF
--- a/pkg/proxy/handler/detected_labels.go
+++ b/pkg/proxy/handler/detected_labels.go
@@ -28,9 +28,8 @@ type LokiDetectedLabelsResponse struct {
 }
 
 // HandleLokiDetectedLabels aggregates detected labels from multiple Loki instances
-func HandleLokiDetectedLabels(w http.ResponseWriter, results <-chan *http.Response, logger log.Logger) {
-	ctx := r.Context()  
-	ctx, span := traces.CreateSpan(context.Background(), "handle_detected_labels")
+func HandleLokiDetectedLabels(ctx context.Context, w http.ResponseWriter, results <-chan *http.Response, logger log.Logger) {
+	ctx, span := traces.CreateSpan(ctx, "handle_detected_labels")
 	defer span.End()
 
 	mergedLabels := make(map[string]int)

--- a/pkg/proxy/handler/detected_labels_test.go
+++ b/pkg/proxy/handler/detected_labels_test.go
@@ -66,7 +66,7 @@ func TestHandleLokiDetectedLabels(t *testing.T) {
 			close(results)
 
 			w := httptest.NewRecorder()
-			HandleLokiDetectedLabels(w, results, logger)
+			HandleLokiDetectedLabels(t.Context(), w, results, logger)
 
 			var resp LokiDetectedLabelsResponse
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
@@ -103,7 +103,7 @@ func TestHandleLokiDetectedLabelsWithMerging(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiDetectedLabels(w, results, logger)
+	HandleLokiDetectedLabels(t.Context(), w, results, logger)
 
 	var resp LokiDetectedLabelsResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
@@ -124,7 +124,7 @@ func TestHandleLokiDetectedLabelsWithInvalidJSON(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiDetectedLabels(w, results, logger)
+	HandleLokiDetectedLabels(t.Context(), w, results, logger)
 
 	var resp LokiDetectedLabelsResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
@@ -144,7 +144,7 @@ func TestHandleLokiDetectedLabelsResponseReaderError(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiDetectedLabels(w, results, logger)
+	HandleLokiDetectedLabels(t.Context(), w, results, logger)
 
 	var out LokiDetectedLabelsResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))


### PR DESCRIPTION
This PR adds support for the detected labels API (`/loki/api/v1/detected_labels`).

All the credits go to https://github.com/marcusteixeira/lokxy/pull/1, as I'm pulling due to lack of response 🙏 

Relates to #22 