### PR TITLE
ci: upgrade golangci-lint to v2 and refactor configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           go-version: "1.24"
       - name: install dependencies
-        run: go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+        run: make lint-install
       - name: Test
         run: make test
       - name: Lint

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,65 +1,68 @@
+version: "2"
 run:
-  # define go version
-  go: "1.24"
-
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 10m
-
-  # exit code when at least one issue was found, default is 1
   issues-exit-code: 1
-
-  # include test files or not, default is true
   tests: true
-
-# output configuration options
 output:
   formats:
-    # colored-line-number|line-number|json|tab|checkstyle, default is "colored-line-number"
-    - format: colored-line-number
-
-  # print lines of code with issue, default is true
-  print-issued-lines: true
-
-  # print linter name in the end of issue text, default is true
-  print-linter-name: true
-
-linters-settings:
-  depguard:
-    rules:
-      Main:
-        deny:
-          - desc: "Use github.com/go-kit/log instead of github.com/go-kit/kit/log"
-            pkg: github.com/go-kit/kit/log
-
+    text:
+      path: stdout
+      print-linter-name: true
+      print-issued-lines: true
 linters:
   enable:
     - copyloopvar
     - depguard
-    - errcheck
-    - gci
-    - goconst
-    - gofmt
     - gochecksumtype
-    - gosimple
+    - goconst
     - govet
+    - errcheck
     - ineffassign
+    - intrange
     - misspell
     - revive
     - staticcheck
     - testifylint
-    - typecheck
     - unconvert
-  disable:
     - unused
+  disable:
     - unparam
-
-issues:
-  exclude:
-    - Error return value of .*log\.Logger\)\.Log\x60 is not checked
-    - defers in this range loop won't run unless the channel gets closed
-    - func name will be used as proxy.ProxyHandler by other packages, and that stutters; consider calling this Handler
-    - ineffectual assignment to dialTimeout
-  exclude-rules:
-    - path: '(.+)_test\.go'
-      linters:
-        - errcheck
+  settings:
+    depguard:
+      rules:
+        Main:
+          deny:
+            - pkg: github.com/go-kit/kit/log
+              desc: Use github.com/go-kit/log instead of github.com/go-kit/kit/log
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - errcheck
+        path: (.+)_test\.go
+      - path: (.+)\.go$
+        text: Error return value of .*log\.Logger\)\.Log\x60 is not checked
+      - path: (.+)\.go$
+        text: defers in this range loop won't run unless the channel gets closed
+      - path: (.+)\.go$
+        text: func name will be used as proxy.ProxyHandler by other packages, and that stutters; consider calling this Handler
+      - path: (.+)\.go$
+        text: ineffectual assignment to dialTimeout
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ BUILD := build
 CONTAINER_ENGINE := $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 GO ?= go
 GOFILES := $(shell find . -name "*.go" -type f ! -path "./vendor/*")
+GOLANGCI_LINT_VERSION:=v2.6.1
 GOLANGCI_LINT ?= golangci-lint
 VERSION := $(shell git describe --tags --abbrev=0)
 REVISION := $(shell git rev-parse --short HEAD)
@@ -27,6 +28,10 @@ run:
 		-ldflags="-X main.Version=$(VERSION) \
 	  			  -X main.Revision=$(REVISION)" \
 		cmd/main.go
+
+.PHONY: lint-install
+lint-install:
+	$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 .PHONY: lint
 lint:

--- a/pkg/o11y/logging/logging_test.go
+++ b/pkg/o11y/logging/logging_test.go
@@ -47,11 +47,12 @@ func TestConfigureLogger(t *testing.T) {
 
 			// Check logger format
 			// Note: This is a simplified check. In a real-world scenario, you might need to capture and parse log output.
-			if tt.config.Format == "json" {
+			switch tt.config.Format {
+			case "json":
 				if _, ok := any(logger).(log.Logger); !ok {
 					t.Errorf("Expected logger to be in json format, got %T", logger)
 				}
-			} else if tt.config.Format == "logfmt" {
+			case "logfmt":
 				if _, ok := any(logger).(log.Logger); !ok {
 					t.Errorf("Expected logger to be in logfmt format, got %T", logger)
 				}

--- a/pkg/proxy/handler/volume.go
+++ b/pkg/proxy/handler/volume.go
@@ -110,8 +110,9 @@ func HandleLokiVolume(ctx context.Context, w http.ResponseWriter, results <-chan
 			metricKey := createMetricKey(volume.Metric)
 
 			if existingVolume, exists := volumeMap[metricKey]; exists {
+				switch volumeResponse.Data.ResultType {
 				// Aggregate values - sum volume data
-				if volumeResponse.Data.ResultType == resultTypeVector {
+				case resultTypeVector:
 					// For vector responses, sum the values
 					if len(volume.Value) >= 2 && len(existingVolume.Value) >= 2 {
 						existingValue := parseVolumeValue(existingVolume.Value[1])
@@ -119,7 +120,7 @@ func HandleLokiVolume(ctx context.Context, w http.ResponseWriter, results <-chan
 						summedValue := existingValue + newValue
 						existingVolume.Value[1] = strconv.FormatInt(summedValue, 10)
 					}
-				} else if volumeResponse.Data.ResultType == resultTypeMatrix {
+				case resultTypeMatrix:
 					// For matrix responses, merge the values arrays
 					existingVolume.Values = mergeMatrixValues(existingVolume.Values, volume.Values)
 				}


### PR DESCRIPTION
## This PR

- Update golangci-lint from v1 to v2.6.1
- Migrate .golangci.yaml to v2 configuration format
- Add lint-install target to Makefile for consistent linter installation
- Update GitHub Actions workflow to use Makefile for linter setup
