### PR TITLE
build: improve Docker build caching in Dockerfile.local

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -5,9 +5,12 @@ ARG TARGETARCH
 ARG TARGETOS
 ENV GOARCH=${TARGETARCH} GOOS=${TARGETOS}
 
-COPY . /go/src/github.com/paulojmdias/lokxy
-RUN cd /go/src/github.com/paulojmdias/lokxy &&\
-    make build
+WORKDIR /go/src/github.com/paulojmdias/lokxy
+COPY go.mod go.sum ./
+RUN go mod download 
+
+COPY . ./
+RUN make build
 
 FROM gcr.io/distroless/static-debian12
 


### PR DESCRIPTION
Split dependency download from source copy to leverage Docker layer
caching. This reduces rebuild time when only application code changes.
