### PR TITLE
refactor: replace http.ListenAndServe with Serve using net.Listener

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -93,7 +93,7 @@ func run(ctx context.Context, logger kitlog.Logger, cfg *config.Config, bindAddr
 	tracerProvider, err := traces.InitTracer(ctx)
 	if err != nil {
 		shutdownErr := meterProvider.Shutdown(ctx)
-        return fmt.Errorf("failed to initialize tracer: %w (meter shutdown error: %v)", err, shutdownErr)
+		return fmt.Errorf("failed to initialize tracer: %w (meter shutdown error: %v)", err, shutdownErr)
 	}
 
 	eg, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
The previous use of WaitGroup was confusing and not well suited for this scenario. This change separates http.ListenAndServe into two explicit steps: binding to the required addresses and then starting the HTTP servers. As a result, the Lokxy readiness state becomes more explicit.

- Replace ListenAndServe with Serve using net.Listener
- Extract main startup flow into `run()` to improve error handling and shutdown cleanup
- Remove WaitGroup synchronization
- Add newProxyServer and newMetricsServer helpers
