### PR TITLE
refactor(metrics): change server group identifier in metrics to server_group

### DIFF
--- a/pkg/proxy/handler/tail.go
+++ b/pkg/proxy/handler/tail.go
@@ -136,7 +136,7 @@ func HandleTailWebSocket(ctx context.Context, w http.ResponseWriter, r *http.Req
 				metrics.RequestFailures.Add(upstreamCtx, 1, metric.WithAttributes(
 					attribute.String("path", "/loki/api/v1/tail"),
 					attribute.String("method", "GET"),
-					attribute.String("instance", instance.Name),
+					attribute.String("server_group", instance.Name),
 				))
 				level.Error(logger).Log("msg", "Failed to create WebSocket dialer", "instance", instance.Name, "err", err)
 				return
@@ -146,7 +146,7 @@ func HandleTailWebSocket(ctx context.Context, w http.ResponseWriter, r *http.Req
 			metrics.RequestCount.Add(upstreamCtx, 1, metric.WithAttributes(
 				attribute.String("path", "/loki/api/v1/tail"),
 				attribute.String("method", "GET"),
-				attribute.String("instance", instance.Name),
+				attribute.String("server_group", instance.Name),
 			))
 
 			// Create WebSocket connection to Loki instance
@@ -165,7 +165,7 @@ func HandleTailWebSocket(ctx context.Context, w http.ResponseWriter, r *http.Req
 				metrics.RequestFailures.Add(upstreamCtx, 1, metric.WithAttributes(
 					attribute.String("path", "/loki/api/v1/tail"),
 					attribute.String("method", "GET"),
-					attribute.String("instance", instance.Name),
+					attribute.String("server_group", instance.Name),
 				))
 				level.Error(logger).Log("msg", "Failed to connect to Loki WebSocket", "instance", instance.Name, "err", err)
 				if resp != nil {
@@ -174,7 +174,7 @@ func HandleTailWebSocket(ctx context.Context, w http.ResponseWriter, r *http.Req
 					metrics.RequestFailures.Add(upstreamCtx, 1, metric.WithAttributes(
 						attribute.String("path", "/loki/api/v1/tail"),
 						attribute.String("method", "GET"),
-						attribute.String("instance", instance.Name),
+						attribute.String("server_group", instance.Name),
 					))
 					body, _ := io.ReadAll(resp.Body)
 					resp.Body.Close()
@@ -204,7 +204,7 @@ func HandleTailWebSocket(ctx context.Context, w http.ResponseWriter, r *http.Req
 					metrics.RequestFailures.Add(upstreamCtx, 1, metric.WithAttributes(
 						attribute.String("path", "/loki/api/v1/tail"),
 						attribute.String("method", "GET"),
-						attribute.String("instance", instance.Name),
+						attribute.String("server_group", instance.Name),
 					))
 					level.Error(logger).Log("msg", "Error reading WebSocket message", "instance", instance.Name, "err", err)
 
@@ -222,7 +222,7 @@ func HandleTailWebSocket(ctx context.Context, w http.ResponseWriter, r *http.Req
 					metrics.RequestFailures.Add(upstreamCtx, 1, metric.WithAttributes(
 						attribute.String("path", "/loki/api/v1/tail"),
 						attribute.String("method", "GET"),
-						attribute.String("instance", instance.Name),
+						attribute.String("server_group", instance.Name),
 					))
 					level.Error(logger).Log("msg", "Failed to decode WebSocket message", "instance", instance.Name, "err", err)
 					backendSpan.SetAttributes(attribute.Int("upstream.messages_received", messageCount))

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -396,7 +396,7 @@ func (p *proxy) fanoutRequest(w http.ResponseWriter, r *http.Request, fn transfo
 			metrics.RequestCount.Add(upstreamCtx, 1, metric.WithAttributes(
 				attribute.String("path", r.URL.Path),
 				attribute.String("method", r.Method),
-				attribute.String("instance", instance.Name),
+				attribute.String("server_group", instance.Name),
 			))
 
 			req, err := http.NewRequestWithContext(upstreamCtx, r.Method, targetURL, bodyReader())
@@ -407,7 +407,7 @@ func (p *proxy) fanoutRequest(w http.ResponseWriter, r *http.Request, fn transfo
 				metrics.RequestFailures.Add(upstreamCtx, 1, metric.WithAttributes(
 					attribute.String("path", r.URL.Path),
 					attribute.String("method", r.Method),
-					attribute.String("instance", instance.Name),
+					attribute.String("server_group", instance.Name),
 				))
 				level.Error(p.logger).Log("msg", "Failed to create request", "instance", instance.Name, "err", err)
 				return &proxyresponse.BackendError{
@@ -440,7 +440,7 @@ func (p *proxy) fanoutRequest(w http.ResponseWriter, r *http.Request, fn transfo
 				metrics.RequestFailures.Add(upstreamCtx, 1, metric.WithAttributes(
 					attribute.String("path", r.URL.Path),
 					attribute.String("method", r.Method),
-					attribute.String("instance", instance.Name),
+					attribute.String("server_group", instance.Name),
 				))
 				level.Error(p.logger).Log("msg", "Error querying Loki instance", "instance", instance.Name, "err", err)
 				return &proxyresponse.BackendError{
@@ -461,7 +461,7 @@ func (p *proxy) fanoutRequest(w http.ResponseWriter, r *http.Request, fn transfo
 				metric.WithAttributes(
 					attribute.String("path", r.URL.Path),
 					attribute.String("method", r.Method),
-					attribute.String("instance", instance.Name),
+					attribute.String("server_group", instance.Name),
 				),
 			)
 
@@ -500,7 +500,7 @@ func (p *proxy) fanoutRequest(w http.ResponseWriter, r *http.Request, fn transfo
 				metrics.RequestFailures.Add(upstreamCtx, 1, metric.WithAttributes(
 					attribute.String("path", r.URL.Path),
 					attribute.String("method", r.Method),
-					attribute.String("instance", instance.Name),
+					attribute.String("server_group", instance.Name),
 				))
 				level.Error(p.logger).Log("msg", "Failed to read upstream response body", "instance", instance.Name, "err", err)
 				return &proxyresponse.BackendError{


### PR DESCRIPTION
Rename `instance` metric attribute to `server_group`

The `instance` is a generic term commonly associated with VMs or hosts, which makes it ambiguous in a multi-backend proxy context. `server_group` better reflects what the label identifies.