### PR TITLE
fix(o11y): Fix high cardinality on path  label

### DIFF
--- a/pkg/o11y/metrics/metrics.go
+++ b/pkg/o11y/metrics/metrics.go
@@ -105,6 +105,14 @@ func createMetrics() error {
 	return nil
 }
 
+// Reinitialize re-creates all metric instruments using the current global
+// [otel.MeterProvider]. This is intended for tests that replace the provider
+// (e.g. with a ManualReader) and need the package-level counters and histograms
+// to point at the new provider.
+func Reinitialize() error {
+	return createMetrics()
+}
+
 // NewServeMux returns an [http.ServeMux] preconfigured with a Prometheus
 // metrics handler.
 //

--- a/pkg/o11y/tracing/traces.go
+++ b/pkg/o11y/tracing/traces.go
@@ -90,10 +90,20 @@ func HTTPTracesHandler(logger log.Logger) func(http.Handler) http.Handler {
 
 			durationMs := float64(time.Since(start).Nanoseconds()) / 1e6
 
+			// After routing, r.Pattern contains the matched route template
+			// (e.g. "/loki/api/v1/label/{name}/values") which keeps span
+			// names bounded. Fall back to r.URL.Path when no ServeMux is used.
+			route := r.Pattern
+			if route == "" {
+				route = r.URL.Path
+			}
+			span.SetName(fmt.Sprintf("%s %s", r.Method, route))
+
 			// define attributes from requests to spans
 			// from convention https://opentelemetry.io/docs/specs/semconv/http/http-spans/
 			span.SetAttributes(
 				attribute.String("http.request.method", r.Method),
+				attribute.String("http.route", route),
 				attribute.String("url.full", r.URL.String()),
 				attribute.String("server.address", r.Host),
 				attribute.String("user_agent.original", r.UserAgent()),
@@ -112,7 +122,7 @@ func HTTPTracesHandler(logger log.Logger) func(http.Handler) http.Handler {
 			level.Info(logger).Log(
 				"msg", "Request completed",
 				"method", r.Method,
-				"path", r.URL.Path,
+				"path", route,
 				"status", wrappedWriter.statusCode,
 				"duration_ms", durationMs,
 			)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -394,7 +394,7 @@ func (p *proxy) fanoutRequest(w http.ResponseWriter, r *http.Request, fn transfo
 
 			// Record the request
 			metrics.RequestCount.Add(upstreamCtx, 1, metric.WithAttributes(
-				attribute.String("path", r.URL.Path),
+				attribute.String("path", r.Pattern),
 				attribute.String("method", r.Method),
 				attribute.String("server_group", instance.Name),
 			))
@@ -405,7 +405,7 @@ func (p *proxy) fanoutRequest(w http.ResponseWriter, r *http.Request, fn transfo
 				requestSpan.SetStatus(codes.Error, "Failed to create request")
 				// Record error count
 				metrics.RequestFailures.Add(upstreamCtx, 1, metric.WithAttributes(
-					attribute.String("path", r.URL.Path),
+					attribute.String("path", r.Pattern),
 					attribute.String("method", r.Method),
 					attribute.String("server_group", instance.Name),
 				))
@@ -438,7 +438,7 @@ func (p *proxy) fanoutRequest(w http.ResponseWriter, r *http.Request, fn transfo
 				requestSpan.SetStatus(codes.Error, "Error querying Loki instance")
 				// Record error count
 				metrics.RequestFailures.Add(upstreamCtx, 1, metric.WithAttributes(
-					attribute.String("path", r.URL.Path),
+					attribute.String("path", r.Pattern),
 					attribute.String("method", r.Method),
 					attribute.String("server_group", instance.Name),
 				))
@@ -459,7 +459,7 @@ func (p *proxy) fanoutRequest(w http.ResponseWriter, r *http.Request, fn transfo
 			// Measure response time
 			metrics.RequestDuration.Record(upstreamCtx, time.Since(startTime).Seconds(),
 				metric.WithAttributes(
-					attribute.String("path", r.URL.Path),
+					attribute.String("path", r.Pattern),
 					attribute.String("method", r.Method),
 					attribute.String("server_group", instance.Name),
 				),
@@ -498,7 +498,7 @@ func (p *proxy) fanoutRequest(w http.ResponseWriter, r *http.Request, fn transfo
 				requestSpan.RecordError(err)
 				requestSpan.SetStatus(codes.Error, "Failed to read upstream response body")
 				metrics.RequestFailures.Add(upstreamCtx, 1, metric.WithAttributes(
-					attribute.String("path", r.URL.Path),
+					attribute.String("path", r.Pattern),
 					attribute.String("method", r.Method),
 					attribute.String("server_group", instance.Name),
 				))

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -17,8 +18,13 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	cfg "github.com/paulojmdias/lokxy/pkg/config"
+	"github.com/paulojmdias/lokxy/pkg/o11y/metrics"
 	"github.com/paulojmdias/lokxy/pkg/proxy/proxyresponse"
 )
 
@@ -814,4 +820,47 @@ func TestFanout_HeaderLoggingRedactsSensitiveValues(t *testing.T) {
 	// Sensitive Authorization value should be redacted
 	require.NotContains(t, buf.String(), "top-secret-token")
 	require.Contains(t, buf.String(), "REDACTED")
+}
+
+func TestMetricPathLabel_UsesRoutePattern(t *testing.T) {
+	// Set up a real OTel meter with a ManualReader so we can inspect attributes.
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	otel.SetMeterProvider(mp)
+	require.NoError(t, metrics.Reinitialize())
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	srv := mkUpstreamServer(t, map[string]http.HandlerFunc{
+		"/loki/api/v1/label/namespace/values": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"status":"success","data":["v1"]}`)
+		},
+	})
+	defer srv.Close()
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/label/namespace/values", nil)
+	NewServeMux(log.NewNopLogger(), mkConfig(srv.URL)).ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Collect metrics and extract the "path" attribute from lokxy_request_count_total.
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	var found string
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "lokxy_request_count_total" {
+				continue
+			}
+			for _, dp := range m.Data.(metricdata.Sum[int64]).DataPoints {
+				if v, ok := dp.Attributes.Value(attribute.Key("path")); ok {
+					found = v.AsString()
+				}
+			}
+		}
+	}
+
+	require.Equal(t, "/loki/api/v1/label/{name}/values", found,
+		"path metric label must be the route template, not the resolved URL")
 }


### PR DESCRIPTION
The path attribute on `lokxy_request_count_total`, `lokxy_request_duration_seconds`, and `lokxy_request_failures_total` uses the raw `r.URL.Path` value in `fanoutRequest()`. For routes with dynamic segments (`/loki/api/v1/label/{name}/values` and `/loki/api/v1/detected_field/{name}/values`), every unique label name or field name in a request creates a distinct time series, causing unbounded metric cardinality.

Since lokxy uses `http.ServeMux`, `r.Pattern` is available after route matching and contains the route template (e.g., `/loki/api/v1/label/{name}/values`). Replacing `r.URL.Path` with `r.Pattern` fixes the issue.

Before:

<img width="2047" height="1025" alt="Image" src="https://github.com/user-attachments/assets/d5108710-8ba8-4aa6-97ba-9dcd6d9e8ed4" />