### PR TITLE
feat: add ignore_error and downgrade_error for partial results

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ server_groups:
     headers:
       Authorization: "Bearer <token>"
       X-Scope-OrgID: org2
+    # Optional group: if it fails the query still succeeds with partial results
+    # (no warning surfaced).
+    ignore_error: true
 
   - name: "Loki 3"
     url: "https://localhost:3102"
@@ -151,6 +154,8 @@ logging:
     * `url`: The base URL of the Loki instance.
     * `timeout`: Timeout for requests in seconds.
     * `headers`: Custom headers to include in each request, such as authentication tokens.
+    * `ignore_error`: When `true`, this server group's response is optional — see [Error Handling and Partial Results](#error-handling-and-partial-results). Default: `false`.
+    * `downgrade_error`: When `true`, this server group's errors are surfaced as warnings instead of failing the query — see [Error Handling and Partial Results](#error-handling-and-partial-results). Default: `false`. Mutually exclusive with `ignore_error`.
     * `http_client_config`: HTTP Client custom configurations
         * `dial_timeout`: Timeout duration for establishing a connection. Defaults to 200ms.
         * `tls_config`:
@@ -170,6 +175,60 @@ logging:
 * `logging`:
     * `level`: Defines the log level (`debug`, `info`, `warn`, `error`).
     * `format`: The log output format, either in `json` or `logfmt`.
+
+### Error Handling and Partial Results
+
+By default lokxy treats every server group as **required**: if any group returns an
+error, the whole query fails. This protects result consistency but hurts availability
+when querying multiple Loki clusters where one may be down for maintenance, degraded,
+or simply optional (e.g. an archive tier).
+
+Two per-server-group options let you trade strict consistency for availability:
+
+* `ignore_error: true` — makes the group's response **optional**. If it fails while at
+  least one other group succeeds, the query still returns `200` with partial results
+  merged from the healthy groups. The failure is **not** surfaced to the client (only
+  logged at debug level and counted in the `lokxy_request_degraded_total` metric).
+
+* `downgrade_error: true` — same partial-results behaviour, but the group's error is
+  **converted into a warning** rather than being silent. For `query`/`query_range` the
+  warning is added to the native Loki `warnings[]` field of the response, which clients
+  such as Grafana render as a panel warning. For other endpoints (labels, series,
+  stats, volume, patterns, detected_*) there is no native warnings field, so the
+  downgrade is surfaced via a warn-level log and the `lokxy_request_degraded_total`
+  metric only.
+
+The two options are **mutually exclusive** — setting both on the same group is a
+configuration error.
+
+Notes:
+
+* A **required** group failing still fails the entire query (default behaviour,
+  unchanged).
+* If **every** contributing group is optional and they **all** fail, lokxy forwards the
+  last upstream error (e.g. `502`/the upstream status) rather than returning a
+  misleading empty `200` — partial results require at least one successful backend.
+* These options apply to the aggregated HTTP query endpoints. The live tail
+  (`/loki/api/v1/tail`, WebSocket) is inherently best-effort per backend — a backend
+  that fails to connect is skipped while the others keep streaming — so it ignores
+  these flags.
+
+Example:
+
+```yaml
+server_groups:
+  - name: primary-cluster
+    url: http://loki-primary:3100
+    # Required: this cluster must respond successfully.
+
+  - name: archive-cluster
+    url: http://loki-archive:3100
+    ignore_error: true     # Optional: queries succeed even if it fails (silent).
+
+  - name: secondary-cluster
+    url: http://loki-secondary:3100
+    downgrade_error: true  # Optional: failures become warnings on the response.
+```
 
 ### Tracing Configuration
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Two per-server-group options let you trade strict consistency for availability:
   merged from the healthy groups. The failure is **not** surfaced to the client (only
   logged at debug level and counted in the `lokxy_request_degraded_total` metric).
 
-* `downgrade_error: true` — same partial-results behaviour, but the group's error is
+* `downgrade_error: true` — same partial-results behavior, but the group's error is
   **converted into a warning** rather than being silent. For `query`/`query_range` the
   warning is added to the native Loki `warnings[]` field of the response, which clients
   such as Grafana render as a panel warning. For other endpoints (labels, series,
@@ -203,7 +203,7 @@ configuration error.
 
 Notes:
 
-* A **required** group failing still fails the entire query (default behaviour,
+* A **required** group failing still fails the entire query (default behavior,
   unchanged).
 * If **every** contributing group is optional and they **all** fail, lokxy forwards the
   last upstream error (e.g. `502`/the upstream status) rather than returning a

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,6 +43,17 @@ type ServerGroup struct {
 	Timeout          int               `yaml:"timeout"`
 	Headers          map[string]string `yaml:"headers"`
 	HTTPClientConfig HTTPClientConfig  `yaml:"http_client_config"` // Add HTTP config
+
+	// IgnoreError makes this server group's response optional: if it fails but
+	// other groups succeed, the overall query still succeeds with partial
+	// results and no warning is surfaced.
+	IgnoreError bool `yaml:"ignore_error"`
+
+	// DowngradeError also makes this server group's response optional, but
+	// converts its errors into warnings surfaced on the merged response instead
+	// of failing the query. IgnoreError and DowngradeError are mutually
+	// exclusive; setting both on the same server group is a configuration error.
+	DowngradeError bool `yaml:"downgrade_error"`
 }
 
 // LoggerConfig contains the logger configuration details.
@@ -90,6 +101,9 @@ func (c *Config) Validate() error {
 		}
 		if sg.URL == "" {
 			return fmt.Errorf("server_groups[%d]: url is required", i)
+		}
+		if sg.IgnoreError && sg.DowngradeError {
+			return fmt.Errorf("server_groups[%d]: ignore_error and downgrade_error are mutually exclusive", i)
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -110,8 +110,31 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		{
+			name:       "error handling fields",
+			configFile: "testdata/error_handling_config.yaml",
+			wantErr:    false,
+			validateFunc: func(t *testing.T, cfg *Config) {
+				require.Len(t, cfg.ServerGroups, 3)
+
+				// Defaults: both flags false when unset.
+				require.False(t, cfg.ServerGroups[0].IgnoreError)
+				require.False(t, cfg.ServerGroups[0].DowngradeError)
+
+				require.True(t, cfg.ServerGroups[1].IgnoreError)
+				require.False(t, cfg.ServerGroups[1].DowngradeError)
+
+				require.False(t, cfg.ServerGroups[2].IgnoreError)
+				require.True(t, cfg.ServerGroups[2].DowngradeError)
+			},
+		},
+		{
 			name:       "invalid empty config",
 			configFile: "testdata/invalid_empty.yaml",
+			wantErr:    true,
+		},
+		{
+			name:       "invalid both error handling flags",
+			configFile: "testdata/invalid_both_error_handling.yaml",
 			wantErr:    true,
 		},
 		{
@@ -179,4 +202,18 @@ func TestValidate_MissingURL(t *testing.T) {
 	err := cfg.Validate()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "url is required")
+}
+
+func TestValidate_MutuallyExclusiveErrorHandling(t *testing.T) {
+	cfg := &Config{
+		ServerGroups: []ServerGroup{{
+			Name:           "loki1",
+			URL:            "http://localhost:3100",
+			IgnoreError:    true,
+			DowngradeError: true,
+		}},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mutually exclusive")
 }

--- a/pkg/config/testdata/error_handling_config.yaml
+++ b/pkg/config/testdata/error_handling_config.yaml
@@ -1,0 +1,15 @@
+server_groups:
+  - name: primary
+    url: http://loki-primary:3100
+    timeout: 30
+  - name: archive
+    url: http://loki-archive:3100
+    timeout: 30
+    ignore_error: true
+  - name: backup
+    url: http://loki-backup:3100
+    timeout: 30
+    downgrade_error: true
+logging:
+  level: info
+  format: json

--- a/pkg/config/testdata/invalid_both_error_handling.yaml
+++ b/pkg/config/testdata/invalid_both_error_handling.yaml
@@ -1,0 +1,8 @@
+server_groups:
+  - name: loki1
+    url: http://localhost:3100
+    ignore_error: true
+    downgrade_error: true
+logging:
+  level: info
+  format: json

--- a/pkg/o11y/metrics/metrics.go
+++ b/pkg/o11y/metrics/metrics.go
@@ -27,6 +27,11 @@ var (
 	// RequestFailures counts the total number of requests that resulted in an
 	// error or failure during processing.
 	RequestFailures metric.Int64Counter = noop.Int64Counter{}
+
+	// RequestDegraded counts upstream failures that did not fail the overall
+	// query because the server group was configured with ignore_error or
+	// downgrade_error. The "outcome" attribute distinguishes the two.
+	RequestDegraded metric.Int64Counter = noop.Int64Counter{}
 )
 
 // Initialize prepares the OpenTelemetry metric pipeline for the service.
@@ -101,6 +106,13 @@ func createMetrics() error {
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create RequestFailures metric: %w", err)
+	}
+
+	RequestDegraded, err = meter.Int64Counter("lokxy_request_degraded_total",
+		metric.WithDescription("Total number of upstream failures tolerated via ignore_error or downgrade_error"),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create RequestDegraded metric: %w", err)
 	}
 	return nil
 }

--- a/pkg/proxy/handler/bench_test.go
+++ b/pkg/proxy/handler/bench_test.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -76,7 +75,7 @@ func BenchmarkHandleLokiLabels(b *testing.B) {
 				w := httptest.NewRecorder()
 				b.StartTimer()
 
-				HandleLokiLabels(context.Background(), w, results, logger)
+				HandleLokiLabels(b.Context(), w, results, nil, logger)
 			}
 		})
 	}
@@ -107,7 +106,7 @@ func BenchmarkHandleLokiQueries(b *testing.B) {
 					w := httptest.NewRecorder()
 					b.StartTimer()
 
-					HandleLokiQueries(context.Background(), w, results, logger)
+					HandleLokiQueries(b.Context(), w, results, nil, logger)
 				}
 			})
 		}
@@ -132,7 +131,7 @@ func BenchmarkHandleLokiSeries(b *testing.B) {
 				w := httptest.NewRecorder()
 				b.StartTimer()
 
-				HandleLokiSeries(context.Background(), w, results, logger)
+				HandleLokiSeries(b.Context(), w, results, nil, logger)
 			}
 		})
 	}

--- a/pkg/proxy/handler/detected_fields.go
+++ b/pkg/proxy/handler/detected_fields.go
@@ -111,7 +111,7 @@ func addDetectedField(merged map[string]*fieldAgg, label, typ string, cardinalit
 
 // HandleLokiDetectedFields aggregates detected fields from multiple Loki instances.
 // Accepts both "fields" and "detectedFields" input envelopes and emits the "fields" envelope.
-func HandleLokiDetectedFields(ctx context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, logger log.Logger) {
+func HandleLokiDetectedFields(ctx context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, _ []string, logger log.Logger) {
 	ctx, span := traces.CreateSpan(ctx, "handle_detected_fields")
 	defer span.End()
 

--- a/pkg/proxy/handler/detected_fields_test.go
+++ b/pkg/proxy/handler/detected_fields_test.go
@@ -44,7 +44,7 @@ func TestDetectedFields_VariantA_Single(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiDetectedFields(t.Context(), w, results, logger)
+	HandleLokiDetectedFields(t.Context(), w, results, nil, logger)
 
 	var out LokiDetectedFieldsOut
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
@@ -76,7 +76,7 @@ func TestDetectedFields_VariantB_Merge(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiDetectedFields(t.Context(), w, results, logger)
+	HandleLokiDetectedFields(t.Context(), w, results, nil, logger)
 
 	var out LokiDetectedFieldsOut
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
@@ -106,7 +106,7 @@ func TestDetectedFields_ParsersUnionAndType(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiDetectedFields(t.Context(), w, results, logger)
+	HandleLokiDetectedFields(t.Context(), w, results, nil, logger)
 
 	var out LokiDetectedFieldsOut
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
@@ -130,7 +130,7 @@ func TestDetectedFields_InvalidJSONAndReaderErr(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiDetectedFields(t.Context(), w, results, logger)
+	HandleLokiDetectedFields(t.Context(), w, results, nil, logger)
 
 	var out LokiDetectedFieldsOut
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
@@ -248,7 +248,7 @@ func TestHandleLokiDetectedFields_NilResponse(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiDetectedFields(t.Context(), w, results, logger)
+	HandleLokiDetectedFields(t.Context(), w, results, nil, logger)
 
 	var out LokiDetectedFieldsOut
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))

--- a/pkg/proxy/handler/detected_labels.go
+++ b/pkg/proxy/handler/detected_labels.go
@@ -30,7 +30,7 @@ type LokiDetectedLabelsResponse struct {
 }
 
 // HandleLokiDetectedLabels aggregates detected labels from multiple Loki instances
-func HandleLokiDetectedLabels(ctx context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, logger log.Logger) {
+func HandleLokiDetectedLabels(ctx context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, _ []string, logger log.Logger) {
 	ctx, span := traces.CreateSpan(ctx, "handle_detected_labels")
 	defer span.End()
 

--- a/pkg/proxy/handler/detected_labels_test.go
+++ b/pkg/proxy/handler/detected_labels_test.go
@@ -67,7 +67,7 @@ func TestHandleLokiDetectedLabels(t *testing.T) {
 			close(results)
 
 			w := httptest.NewRecorder()
-			HandleLokiDetectedLabels(t.Context(), w, results, logger)
+			HandleLokiDetectedLabels(t.Context(), w, results, nil, logger)
 
 			var resp LokiDetectedLabelsResponse
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
@@ -104,7 +104,7 @@ func TestHandleLokiDetectedLabelsWithMerging(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiDetectedLabels(t.Context(), w, results, logger)
+	HandleLokiDetectedLabels(t.Context(), w, results, nil, logger)
 
 	var resp LokiDetectedLabelsResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
@@ -125,7 +125,7 @@ func TestHandleLokiDetectedLabelsWithInvalidJSON(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiDetectedLabels(t.Context(), w, results, logger)
+	HandleLokiDetectedLabels(t.Context(), w, results, nil, logger)
 
 	var resp LokiDetectedLabelsResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
@@ -145,7 +145,7 @@ func TestHandleLokiDetectedLabelsResponseReaderError(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiDetectedLabels(t.Context(), w, results, logger)
+	HandleLokiDetectedLabels(t.Context(), w, results, nil, logger)
 
 	var out LokiDetectedLabelsResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
@@ -161,7 +161,7 @@ func TestHandleLokiDetectedLabels_NilResponse(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiDetectedLabels(t.Context(), w, results, logger)
+	HandleLokiDetectedLabels(t.Context(), w, results, nil, logger)
 
 	var out LokiDetectedLabelsResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))

--- a/pkg/proxy/handler/labels.go
+++ b/pkg/proxy/handler/labels.go
@@ -13,7 +13,7 @@ import (
 	"github.com/paulojmdias/lokxy/pkg/proxy/proxyresponse"
 )
 
-func HandleLokiLabels(_ context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, logger log.Logger) {
+func HandleLokiLabels(_ context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, _ []string, logger log.Logger) {
 	mergedLabelValues := make(map[string]struct{})
 
 	for backendResp := range results {

--- a/pkg/proxy/handler/labels_test.go
+++ b/pkg/proxy/handler/labels_test.go
@@ -28,7 +28,7 @@ func TestHandleLokiLabels_SingleResponse(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiLabels(t.Context(), w, results, logger)
+	HandleLokiLabels(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -57,7 +57,7 @@ func TestHandleLokiLabels_MultipleResponses(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiLabels(t.Context(), w, results, logger)
+	HandleLokiLabels(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -92,7 +92,7 @@ func TestHandleLokiLabels_EmptyResponse(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiLabels(t.Context(), w, results, logger)
+	HandleLokiLabels(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -113,7 +113,7 @@ func TestHandleLokiLabels_InvalidJSON(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiLabels(t.Context(), w, results, logger)
+	HandleLokiLabels(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -136,7 +136,7 @@ func TestHandleLokiLabels_ResponseReaderError(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiLabels(t.Context(), w, results, logger)
+	HandleLokiLabels(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -167,7 +167,7 @@ func TestHandleLokiLabels_DuplicateLabelsAcrossBackends(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiLabels(t.Context(), w, results, logger)
+	HandleLokiLabels(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -205,7 +205,7 @@ func TestHandleLokiLabels_PartialFailure(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiLabels(t.Context(), w, results, logger)
+	HandleLokiLabels(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))

--- a/pkg/proxy/handler/patterns.go
+++ b/pkg/proxy/handler/patterns.go
@@ -32,7 +32,7 @@ type LokiPatternsResponse struct {
 }
 
 // HandleLokiPatterns aggregates /patterns responses from multiple Loki instances.
-func HandleLokiPatterns(ctx context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, logger log.Logger) {
+func HandleLokiPatterns(ctx context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, _ []string, logger log.Logger) {
 	ctx, span := traces.CreateSpan(ctx, "handle_patterns")
 	defer span.End()
 

--- a/pkg/proxy/handler/patterns_test.go
+++ b/pkg/proxy/handler/patterns_test.go
@@ -33,7 +33,7 @@ func TestHandleLokiPatterns_SingleResponse(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiPatterns(t.Context(), w, results, logger)
+	HandleLokiPatterns(t.Context(), w, results, nil, logger)
 
 	var out LokiPatternsResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
@@ -79,7 +79,7 @@ func TestHandleLokiPatterns_MergeAcrossBackends(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiPatterns(t.Context(), w, results, logger)
+	HandleLokiPatterns(t.Context(), w, results, nil, logger)
 
 	var out LokiPatternsResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
@@ -118,7 +118,7 @@ func TestHandleLokiPatterns_Empty(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiPatterns(t.Context(), w, results, logger)
+	HandleLokiPatterns(t.Context(), w, results, nil, logger)
 
 	var out LokiPatternsResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
@@ -135,7 +135,7 @@ func TestHandleLokiPatterns_InvalidJSON(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiPatterns(t.Context(), w, results, logger)
+	HandleLokiPatterns(t.Context(), w, results, nil, logger)
 
 	var out LokiPatternsResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
@@ -155,7 +155,7 @@ func TestHandleLokiPatterns_ResponseReaderError(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiPatterns(t.Context(), w, results, logger)
+	HandleLokiPatterns(t.Context(), w, results, nil, logger)
 
 	var out LokiPatternsResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
@@ -170,7 +170,7 @@ func TestHandleLokiPatterns_NilResponse(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiPatterns(t.Context(), w, results, logger)
+	HandleLokiPatterns(t.Context(), w, results, nil, logger)
 
 	var out LokiPatternsResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))

--- a/pkg/proxy/handler/query.go
+++ b/pkg/proxy/handler/query.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -28,7 +29,7 @@ type encodingFlagsEnvelope struct {
 }
 
 // Handle Loki query and query_range responses
-func HandleLokiQueries(_ context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, logger log.Logger) {
+func HandleLokiQueries(_ context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, warnings []string, logger log.Logger) {
 	var mergedStreams []loghttp.Stream
 	var mergedMatrix loghttp.Matrix
 	var mergedVector loghttp.Vector
@@ -76,6 +77,10 @@ func HandleLokiQueries(_ context.Context, w http.ResponseWriter, results <-chan 
 		}
 
 		resultType = queryResult.Data.ResultType
+
+		// Preserve any warnings the upstream itself returned (Loki populates
+		// the native warnings[] field, e.g. for incomplete results).
+		warnings = append(warnings, queryResult.Warnings...)
 
 		// Process based on ResultType
 		switch queryResult.Data.ResultType {
@@ -250,6 +255,14 @@ func HandleLokiQueries(_ context.Context, w http.ResponseWriter, results <-chan 
 			"result":     finalResult,
 			"stats":      mergedStats,
 		},
+	}
+
+	// Surface warnings (downgraded server-group errors and any upstream
+	// warnings) on the native Loki warnings[] field so clients such as Grafana
+	// can display them.
+	if len(warnings) > 0 {
+		slices.Sort(warnings)
+		finalResponse["warnings"] = slices.Compact(warnings)
 	}
 
 	// Convert map back to a slice of strings

--- a/pkg/proxy/handler/query_test.go
+++ b/pkg/proxy/handler/query_test.go
@@ -49,7 +49,7 @@ func TestHandleLokiQueries_StreamResult(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiQueries(t.Context(), w, results, logger)
+	HandleLokiQueries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -91,7 +91,7 @@ func TestHandleLokiQueries_MatrixResult(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiQueries(t.Context(), w, results, logger)
+	HandleLokiQueries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -134,7 +134,7 @@ func TestHandleLokiQueries_VectorResult(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiQueries(t.Context(), w, results, logger)
+	HandleLokiQueries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -190,7 +190,7 @@ func TestHandleLokiQueries_MultipleStreamResponses(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiQueries(t.Context(), w, results, logger)
+	HandleLokiQueries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -224,7 +224,7 @@ func TestHandleLokiQueries_WithEncodingFlags(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiQueries(t.Context(), w, results, logger)
+	HandleLokiQueries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -263,7 +263,7 @@ func TestHandleLokiQueries_WithStructuredMetadata(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiQueries(t.Context(), w, results, logger)
+	HandleLokiQueries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -293,7 +293,7 @@ func TestHandleLokiQueries_EmptyResult(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiQueries(t.Context(), w, results, logger)
+	HandleLokiQueries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -318,7 +318,7 @@ func TestHandleLokiQueries_InvalidJSON(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiQueries(t.Context(), w, results, logger)
+	HandleLokiQueries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -344,7 +344,7 @@ func TestHandleLokiQueries_ResponseReaderError(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiQueries(t.Context(), w, results, logger)
+	HandleLokiQueries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -396,7 +396,7 @@ func TestHandleLokiQueries_PartialFailure(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiQueries(t.Context(), w, results, logger)
+	HandleLokiQueries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -417,7 +417,7 @@ func TestHandleLokiQueries_NoResponses(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiQueries(t.Context(), w, results, logger)
+	HandleLokiQueries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -464,7 +464,7 @@ func TestHandleLokiQueries_MultipleEncodingFlagsDeduplication(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiQueries(t.Context(), w, results, logger)
+	HandleLokiQueries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -499,7 +499,7 @@ func TestHandleLokiQueries_NoEncodingFlags(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiQueries(t.Context(), w, results, logger)
+	HandleLokiQueries(t.Context(), w, results, nil, logger)
 
 	var got map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
@@ -534,7 +534,7 @@ func TestHandleLokiQueries_EmptyBody(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiQueries(t.Context(), w, results, logger)
+	HandleLokiQueries(t.Context(), w, results, nil, logger)
 
 	// Should still produce a valid (empty) encoded response
 	require.NotEmpty(t, w.Body.Bytes())
@@ -591,7 +591,7 @@ func TestHandleLokiQueries_VectorSumMerge(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiQueries(t.Context(), w, results, logger)
+	HandleLokiQueries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -649,7 +649,7 @@ func TestHandleLokiQueries_VectorSumMergeDifferentMetrics(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiQueries(t.Context(), w, results, logger)
+	HandleLokiQueries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -706,7 +706,7 @@ func TestHandleLokiQueries_MatrixSumMerge(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiQueries(t.Context(), w, results, logger)
+	HandleLokiQueries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))

--- a/pkg/proxy/handler/series.go
+++ b/pkg/proxy/handler/series.go
@@ -12,7 +12,7 @@ import (
 	"github.com/paulojmdias/lokxy/pkg/proxy/proxyresponse"
 )
 
-func HandleLokiSeries(_ context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, logger log.Logger) {
+func HandleLokiSeries(_ context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, _ []string, logger log.Logger) {
 	var mergedSeries []map[string]string // Assuming series is a map of labels
 
 	for backendResp := range results {

--- a/pkg/proxy/handler/series_test.go
+++ b/pkg/proxy/handler/series_test.go
@@ -31,7 +31,7 @@ func TestHandleLokiSeries_SingleResponse(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiSeries(t.Context(), w, results, logger)
+	HandleLokiSeries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -77,7 +77,7 @@ func TestHandleLokiSeries_MultipleResponses(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiSeries(t.Context(), w, results, logger)
+	HandleLokiSeries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -102,7 +102,7 @@ func TestHandleLokiSeries_EmptyResponse(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiSeries(t.Context(), w, results, logger)
+	HandleLokiSeries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -124,7 +124,7 @@ func TestHandleLokiSeries_InvalidJSON(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiSeries(t.Context(), w, results, logger)
+	HandleLokiSeries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -148,7 +148,7 @@ func TestHandleLokiSeries_ResponseReaderError(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiSeries(t.Context(), w, results, logger)
+	HandleLokiSeries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -184,7 +184,7 @@ func TestHandleLokiSeries_PartialFailure(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiSeries(t.Context(), w, results, logger)
+	HandleLokiSeries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -215,7 +215,7 @@ func TestHandleLokiSeries_DuplicateSeriesAcrossBackends(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiSeries(t.Context(), w, results, logger)
+	HandleLokiSeries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -259,7 +259,7 @@ func TestHandleLokiSeries_ComplexLabels(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiSeries(t.Context(), w, results, logger)
+	HandleLokiSeries(t.Context(), w, results, nil, logger)
 
 	var response map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
@@ -288,7 +288,7 @@ func TestHandleLokiSeries_EmptyData(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiSeries(t.Context(), w, results, logger)
+	HandleLokiSeries(t.Context(), w, results, nil, logger)
 
 	var out struct {
 		Status string              `json:"status"`

--- a/pkg/proxy/handler/stats.go
+++ b/pkg/proxy/handler/stats.go
@@ -12,7 +12,7 @@ import (
 	"github.com/paulojmdias/lokxy/pkg/proxy/proxyresponse"
 )
 
-func HandleLokiStats(_ context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, logger log.Logger) {
+func HandleLokiStats(_ context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, _ []string, logger log.Logger) {
 	var totalStreams, totalChunks, totalBytes, totalEntries int
 
 	for backendResp := range results {

--- a/pkg/proxy/handler/stats_test.go
+++ b/pkg/proxy/handler/stats_test.go
@@ -46,7 +46,7 @@ func TestHandleLokiStats_SingleResponse(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiStats(t.Context(), w, results, logger)
+	HandleLokiStats(t.Context(), w, results, nil, logger)
 
 	response := decodeStatsResponse(t, w)
 
@@ -74,7 +74,7 @@ func TestHandleLokiStats_MultipleResponses(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiStats(t.Context(), w, results, logger)
+	HandleLokiStats(t.Context(), w, results, nil, logger)
 
 	response := decodeStatsResponse(t, w)
 
@@ -97,7 +97,7 @@ func TestHandleLokiStats_EmptyStats(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiStats(t.Context(), w, results, logger)
+	HandleLokiStats(t.Context(), w, results, nil, logger)
 
 	response := decodeStatsResponse(t, w)
 
@@ -117,7 +117,7 @@ func TestHandleLokiStats_InvalidJSON(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiStats(t.Context(), w, results, logger)
+	HandleLokiStats(t.Context(), w, results, nil, logger)
 
 	response := decodeStatsResponse(t, w)
 
@@ -139,7 +139,7 @@ func TestHandleLokiStats_ResponseReaderError(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiStats(t.Context(), w, results, logger)
+	HandleLokiStats(t.Context(), w, results, nil, logger)
 
 	response := decodeStatsResponse(t, w)
 
@@ -173,7 +173,7 @@ func TestHandleLokiStats_PartialFailure(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiStats(t.Context(), w, results, logger)
+	HandleLokiStats(t.Context(), w, results, nil, logger)
 
 	response := decodeStatsResponse(t, w)
 
@@ -201,7 +201,7 @@ func TestHandleLokiStats_LargeNumbers(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiStats(t.Context(), w, results, logger)
+	HandleLokiStats(t.Context(), w, results, nil, logger)
 
 	response := decodeStatsResponse(t, w)
 
@@ -229,7 +229,7 @@ func TestHandleLokiStats_MixedZeroAndNonZero(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiStats(t.Context(), w, results, logger)
+	HandleLokiStats(t.Context(), w, results, nil, logger)
 
 	response := decodeStatsResponse(t, w)
 
@@ -247,7 +247,7 @@ func TestHandleLokiStats_NoResponses(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiStats(t.Context(), w, results, logger)
+	HandleLokiStats(t.Context(), w, results, nil, logger)
 
 	response := decodeStatsResponse(t, w)
 
@@ -269,7 +269,7 @@ func TestHandleLokiStats_EmptyBody(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiStats(t.Context(), w, results, logger)
+	HandleLokiStats(t.Context(), w, results, nil, logger)
 
 	response := decodeStatsResponse(t, w)
 	require.Equal(t, 0, response.Streams)

--- a/pkg/proxy/handler/volume.go
+++ b/pkg/proxy/handler/volume.go
@@ -46,7 +46,7 @@ type Volume struct {
 }
 
 // HandleLokiVolume aggregates volume data from multiple Loki instances
-func HandleLokiVolume(ctx context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, logger log.Logger) {
+func HandleLokiVolume(ctx context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, _ []string, logger log.Logger) {
 	ctx, span := traces.CreateSpan(ctx, "handle_volume")
 	defer span.End()
 
@@ -173,7 +173,7 @@ func HandleLokiVolume(ctx context.Context, w http.ResponseWriter, results <-chan
 }
 
 // HandleLokiVolumeRange handles the volume_range endpoint
-func HandleLokiVolumeRange(ctx context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, logger log.Logger) {
+func HandleLokiVolumeRange(ctx context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, _ []string, logger log.Logger) {
 	ctx, span := traces.CreateSpan(ctx, "handle_volume_range")
 	defer span.End()
 

--- a/pkg/proxy/handler/volume_test.go
+++ b/pkg/proxy/handler/volume_test.go
@@ -96,7 +96,7 @@ func TestHandleLokiVolume(t *testing.T) {
 			close(results)
 
 			w := httptest.NewRecorder()
-			HandleLokiVolume(t.Context(), w, results, logger)
+			HandleLokiVolume(t.Context(), w, results, nil, logger)
 
 			var volumeResponse VolumeResponse
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &volumeResponse))
@@ -117,7 +117,7 @@ func TestHandleLokiVolumeWithInvalidJSON(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiVolume(t.Context(), w, results, logger)
+	HandleLokiVolume(t.Context(), w, results, nil, logger)
 
 	var volumeResponse VolumeResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &volumeResponse))
@@ -138,7 +138,7 @@ func TestHandleLokiVolumeResponseReaderError(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiVolume(t.Context(), w, results, logger)
+	HandleLokiVolume(t.Context(), w, results, nil, logger)
 
 	var volumeResponse VolumeResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &volumeResponse))
@@ -243,7 +243,7 @@ func TestHandleLokiVolume_SameMetricSumming(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiVolume(t.Context(), w, results, logger)
+	HandleLokiVolume(t.Context(), w, results, nil, logger)
 
 	var resp VolumeResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
@@ -259,7 +259,7 @@ func TestHandleLokiVolume_NilResponseBody(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiVolume(t.Context(), w, results, logger)
+	HandleLokiVolume(t.Context(), w, results, nil, logger)
 
 	var resp VolumeResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
@@ -282,7 +282,7 @@ func TestHandleLokiVolumeRange_SameMetricMerging(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiVolumeRange(t.Context(), w, results, logger)
+	HandleLokiVolumeRange(t.Context(), w, results, nil, logger)
 
 	var resp VolumeResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
@@ -301,7 +301,7 @@ func TestHandleLokiVolumeRange_InvalidJSON(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiVolumeRange(t.Context(), w, results, logger)
+	HandleLokiVolumeRange(t.Context(), w, results, nil, logger)
 
 	var resp VolumeResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
@@ -316,7 +316,7 @@ func TestHandleLokiVolumeRange_ReadError(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiVolumeRange(t.Context(), w, results, logger)
+	HandleLokiVolumeRange(t.Context(), w, results, nil, logger)
 
 	var resp VolumeResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
@@ -331,7 +331,7 @@ func TestHandleLokiVolumeRange_NilResponseBody(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	HandleLokiVolumeRange(t.Context(), w, results, logger)
+	HandleLokiVolumeRange(t.Context(), w, results, nil, logger)
 
 	var resp VolumeResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
@@ -414,7 +414,7 @@ func TestHandleLokiVolumeRange(t *testing.T) {
 			close(results)
 
 			w := httptest.NewRecorder()
-			HandleLokiVolumeRange(t.Context(), w, results, logger)
+			HandleLokiVolumeRange(t.Context(), w, results, nil, logger)
 
 			var volumeResponse VolumeResponse
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &volumeResponse))

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -191,7 +191,14 @@ type (
 		logger  log.Logger
 		clients map[string]*http.Client
 	}
-	transformFn func(context.Context, http.ResponseWriter, <-chan *proxyresponse.BackendResponse, log.Logger)
+	transformFn func(context.Context, http.ResponseWriter, <-chan *proxyresponse.BackendResponse, []string, log.Logger)
+
+	// softFailure is an upstream failure from a server group configured with
+	// ignore_error or downgrade_error. It does not fail the overall query.
+	softFailure struct {
+		berr      *proxyresponse.BackendError
+		downgrade bool // true => surface as a warning; false => ignore silently
+	}
 )
 
 func proxyHandler(config *cfg.Config, logger log.Logger) func(http.ResponseWriter, *http.Request) {
@@ -228,7 +235,7 @@ func proxyHandler(config *cfg.Config, logger log.Logger) func(http.ResponseWrite
 		span := trace.SpanFromContext(r.Context())
 		span.SetAttributes(attribute.String("proxy.route_type", "detected_field_values"))
 		fieldName := r.PathValue("name")
-		p.fanoutRequest(w, r, func(ctx context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, logger log.Logger) {
+		p.fanoutRequest(w, r, func(ctx context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, _ []string, logger log.Logger) {
 			handler.HandleLokiDetectedFieldValues(ctx, w, results, fieldName, logger)
 		})
 	})
@@ -299,7 +306,7 @@ func proxyHandler(config *cfg.Config, logger log.Logger) func(http.ResponseWrite
 }
 
 // Forward the first valid response for non-query endpoints
-func forwardFirstResponse(_ context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, logger log.Logger) {
+func forwardFirstResponse(_ context.Context, w http.ResponseWriter, results <-chan *proxyresponse.BackendResponse, _ []string, logger log.Logger) {
 	forwarded := false
 	for backendResp := range results {
 		resp := backendResp.Response
@@ -361,12 +368,29 @@ func (p *proxy) fanoutRequest(w http.ResponseWriter, r *http.Request, fn transfo
 		return io.NopCloser(bytes.NewReader(bodyBytes))
 	}
 	results := make(chan *proxyresponse.BackendResponse, len(p.config.ServerGroups))
+	// softErrs collects failures from server groups configured with
+	// ignore_error/downgrade_error so they do not fail the overall query.
+	softErrs := make(chan softFailure, len(p.config.ServerGroups))
 	ctx := r.Context()
 
 	// Forward requests using the custom RoundTripper
 	wg, ctx := errgroup.WithContext(ctx)
 	for _, instance := range p.config.ServerGroups {
 		wg.Go(func() error {
+			// Classify this server group's error-handling policy. A required
+			// group (the default) fails the whole query on error; an optional
+			// group's failure is recorded as a soft failure instead. The two
+			// flags are mutually exclusive (enforced by config.Validate).
+			optional := instance.IgnoreError || instance.DowngradeError
+			downgrade := instance.DowngradeError
+			recordFailure := func(berr *proxyresponse.BackendError) error {
+				if !optional {
+					return berr
+				}
+				softErrs <- softFailure{berr: berr, downgrade: downgrade}
+				return nil
+			}
+
 			upstreamCtx, requestSpan := traces.CreateSpan(ctx, "proxy_upstream_request", trace.WithSpanKind(trace.SpanKindClient))
 			defer requestSpan.End()
 
@@ -379,11 +403,11 @@ func (p *proxy) fanoutRequest(w http.ResponseWriter, r *http.Request, fn transfo
 			if !ok {
 				requestSpan.SetStatus(codes.Error, "Missing HTTP client")
 				level.Error(p.logger).Log("msg", "Missing HTTP client", "instance", instance.Name)
-				return &proxyresponse.BackendError{
+				return recordFailure(&proxyresponse.BackendError{
 					Err:         fmt.Errorf("missing HTTP client for instance %s", instance.Name),
 					BackendName: instance.Name,
 					BackendURL:  instance.URL,
-				}
+				})
 			}
 
 			targetURL := instance.URL + r.URL.Path
@@ -411,11 +435,11 @@ func (p *proxy) fanoutRequest(w http.ResponseWriter, r *http.Request, fn transfo
 					attribute.String("server_group", instance.Name),
 				))
 				level.Error(p.logger).Log("msg", "Failed to create request", "instance", instance.Name, "err", err)
-				return &proxyresponse.BackendError{
+				return recordFailure(&proxyresponse.BackendError{
 					Err:         err,
 					BackendName: instance.Name,
 					BackendURL:  instance.URL,
-				}
+				})
 			}
 
 			req.Header = r.Header.Clone()
@@ -444,11 +468,11 @@ func (p *proxy) fanoutRequest(w http.ResponseWriter, r *http.Request, fn transfo
 					attribute.String("server_group", instance.Name),
 				))
 				level.Error(p.logger).Log("msg", "Error querying Loki instance", "instance", instance.Name, "err", err)
-				return &proxyresponse.BackendError{
+				return recordFailure(&proxyresponse.BackendError{
 					Err:         err,
 					BackendName: instance.Name,
 					BackendURL:  instance.URL,
-				}
+				})
 			}
 
 			requestSpan.SetAttributes(
@@ -485,13 +509,13 @@ func (p *proxy) fanoutRequest(w http.ResponseWriter, r *http.Request, fn transfo
 					)
 					bodyBytes = []byte("Failed to read error response")
 				}
-				return &proxyresponse.BackendError{
+				return recordFailure(&proxyresponse.BackendError{
 					Err:         fmt.Errorf("non-2xx response from the upstream: %s", instance.Name),
 					BackendName: instance.Name,
 					BackendURL:  instance.URL,
 					StatusCode:  resp.StatusCode,
 					Data:        bodyBytes,
-				}
+				})
 			}
 			respBodyBytes, err := io.ReadAll(resp.Body)
 			_ = resp.Body.Close()
@@ -504,11 +528,11 @@ func (p *proxy) fanoutRequest(w http.ResponseWriter, r *http.Request, fn transfo
 					attribute.String("server_group", instance.Name),
 				))
 				level.Error(p.logger).Log("msg", "Failed to read upstream response body", "instance", instance.Name, "err", err)
-				return &proxyresponse.BackendError{
+				return recordFailure(&proxyresponse.BackendError{
 					Err:         err,
 					BackendName: instance.Name,
 					BackendURL:  instance.URL,
-				}
+				})
 			}
 			resp.Body = io.NopCloser(bytes.NewReader(respBodyBytes))
 			resp.ContentLength = int64(len(respBodyBytes))
@@ -523,6 +547,7 @@ func (p *proxy) fanoutRequest(w http.ResponseWriter, r *http.Request, fn transfo
 	// Await for all responses
 	err := wg.Wait()
 	close(results)
+	close(softErrs)
 	if err != nil {
 		berr := &proxyresponse.BackendError{}
 		if errors.As(err, &berr) {
@@ -551,6 +576,48 @@ func (p *proxy) fanoutRequest(w http.ResponseWriter, r *http.Request, fn transfo
 		return
 	}
 
+	// No required server group failed. Process soft failures (optional groups
+	// configured with ignore_error/downgrade_error): downgraded ones become
+	// warnings on the merged response, ignored ones are silent.
+	var warnings []string
+	var lastSoft *proxyresponse.BackendError
+	softCount := 0
+	for sf := range softErrs {
+		softCount++
+		lastSoft = sf.berr
+		outcome := "ignored"
+		if sf.downgrade {
+			outcome = "downgraded"
+			msg := sf.berr.Error()
+			if sf.berr.StatusCode != 0 {
+				msg = fmt.Sprintf("status %d: %s", sf.berr.StatusCode, strings.TrimSpace(string(sf.berr.Data)))
+			}
+			warnings = append(warnings, fmt.Sprintf("server group %q error downgraded to warning: %s", sf.berr.BackendName, msg))
+			level.Warn(p.logger).Log("msg", "Server group error downgraded to warning", "instance", sf.berr.BackendName, "err", sf.berr.Error())
+		} else {
+			level.Debug(p.logger).Log("msg", "Server group error ignored", "instance", sf.berr.BackendName, "err", sf.berr.Error())
+		}
+		metrics.RequestDegraded.Add(r.Context(), 1, metric.WithAttributes(
+			attribute.String("path", r.Pattern),
+			attribute.String("method", r.Method),
+			attribute.String("server_group", sf.berr.BackendName),
+			attribute.String("outcome", outcome),
+		))
+	}
+
+	// If every contributing server group was optional and all of them failed,
+	// there is no data to merge. Forward the last failure rather than return a
+	// misleading empty success.
+	if len(results) == 0 && softCount > 0 {
+		level.Error(p.logger).Log("msg", "All optional server groups failed", "instance", lastSoft.BackendName)
+		if lastSoft.StatusCode != 0 {
+			proxyresponse.ForwardBackendError(w, lastSoft.BackendName, lastSoft.StatusCode, lastSoft.Data, p.logger)
+		} else {
+			proxyresponse.ForwardConnectionError(w, lastSoft, p.logger)
+		}
+		return
+	}
+
 	// Combine responses into expected response
-	fn(r.Context(), w, results, p.logger)
+	fn(r.Context(), w, results, warnings, p.logger)
 }

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -473,6 +473,103 @@ func TestProxy_NoHealthyUpstreams_Returns502(t *testing.T) {
 	require.Contains(t, responseBody, "connection refused")
 }
 
+// streamResultBody is a minimal Loki streams response used by the
+// error-handling tests below.
+const streamResultBody = `{"status":"success","data":{"resultType":"streams","result":[{"stream":{"app":"a"},"values":[["1609459200000000000","hello"]]}],"stats":{}}}`
+
+// ignore_error: a failing optional group is excluded; the query still succeeds
+// with partial results and no warning is surfaced.
+func TestProxy_IgnoreError_PartialResultsNoWarning(t *testing.T) {
+	logger := log.NewNopLogger()
+
+	s1 := mkUpstreamServer(t, map[string]http.HandlerFunc{
+		"/loki/api/v1/query_range": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, streamResultBody)
+		},
+	})
+	defer s1.Close()
+	s2 := mkUpstreamServer(t, map[string]http.HandlerFunc{
+		"/loki/api/v1/query_range": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			io.WriteString(w, "boom")
+		},
+	})
+	defer s2.Close()
+
+	cfg := mkConfig(s1.URL, s2.URL)
+	cfg.ServerGroups[1].IgnoreError = true // sg2 optional
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?query={app=\"a\"}", nil)
+	NewServeMux(logger, cfg).ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), "hello")
+	require.NotContains(t, rr.Body.String(), "warnings")
+}
+
+// downgrade_error: a failing optional group is excluded but its error is
+// surfaced as a warning on the merged response.
+func TestProxy_DowngradeError_SurfacesWarning(t *testing.T) {
+	logger := log.NewNopLogger()
+
+	s1 := mkUpstreamServer(t, map[string]http.HandlerFunc{
+		"/loki/api/v1/query_range": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, streamResultBody)
+		},
+	})
+	defer s1.Close()
+	s2 := mkUpstreamServer(t, map[string]http.HandlerFunc{
+		"/loki/api/v1/query_range": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			io.WriteString(w, "boom")
+		},
+	})
+	defer s2.Close()
+
+	cfg := mkConfig(s1.URL, s2.URL)
+	cfg.ServerGroups[1].DowngradeError = true // sg2 optional
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?query={app=\"a\"}", nil)
+	NewServeMux(logger, cfg).ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	require.Contains(t, body, "hello")
+	require.Contains(t, body, "warnings")
+	require.Contains(t, body, "sg2") // failing group name
+	require.Contains(t, body, "downgraded")
+}
+
+// When every contributing group is optional and all fail, forward the last
+// failure instead of returning a misleading empty success.
+func TestProxy_AllOptionalGroupsFail_ForwardsError(t *testing.T) {
+	logger := log.NewNopLogger()
+
+	fail := func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		io.WriteString(w, "boom")
+	}
+	s1 := mkUpstreamServer(t, map[string]http.HandlerFunc{"/loki/api/v1/query_range": fail})
+	defer s1.Close()
+	s2 := mkUpstreamServer(t, map[string]http.HandlerFunc{"/loki/api/v1/query_range": fail})
+	defer s2.Close()
+
+	cfg := mkConfig(s1.URL, s2.URL)
+	cfg.ServerGroups[0].IgnoreError = true
+	cfg.ServerGroups[1].DowngradeError = true
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/loki/api/v1/query_range?query={app=\"a\"}", nil)
+	NewServeMux(logger, cfg).ServeHTTP(rr, req)
+
+	require.GreaterOrEqual(t, rr.Code, 400)
+	require.Contains(t, rr.Header().Get("Failed-Backend"), "sg")
+}
+
 // roundTripFunc lets us use a plain function as an http.RoundTripper in tests.
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
@@ -560,7 +657,7 @@ func TestForwardFirstResponse_MultipleBackends(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	forwardFirstResponse(t.Context(), w, results, logger)
+	forwardFirstResponse(t.Context(), w, results, nil, logger)
 
 	require.Equal(t, http.StatusOK, w.Code)
 	require.Equal(t, body1, w.Body.String())
@@ -573,7 +670,7 @@ func TestForwardFirstResponse_NoResponses(t *testing.T) {
 	close(results)
 
 	w := httptest.NewRecorder()
-	forwardFirstResponse(t.Context(), w, results, logger)
+	forwardFirstResponse(t.Context(), w, results, nil, logger)
 
 	require.Equal(t, http.StatusBadGateway, w.Code)
 	require.Contains(t, w.Body.String(), "No healthy upstreams available")


### PR DESCRIPTION
## What

Adds per-server-group error handling so a single failing Loki backend no longer fails the whole query.

- `ignore_error: true` — the group's response becomes optional; if it fails while another group succeeds, the query returns partial results with no client-facing signal.
- `downgrade_error: true` — same partial-results behavior, but the failure is surfaced as a warning. For `query`/`query_range`, it's added to Loki's native `warnings[]` field, which Grafana renders as a panel warning badge.

The two flags are mutually exclusive (rejected by config validation). Default behavior is unchanged: a required group failing still fails the query, and if every contributing group is optional and all fail, lokxy forwards the last upstream error instead of an empty `200`.

Closes #135.

## Changes

- Config: `IgnoreError` / `DowngradeError` fields + mutual-exclusion validation.
- Fanout: optional-group failures are collected as soft failures instead of failing the errgroup; warnings are built post-merge.
- Query handler: injects downgrade + upstream warnings into the response `warnings[]`.
- New `lokxy_request_degraded_total` metric (`outcome=ignored|downgraded`).
- README section + example config updates.

## Testing

- Unit tests for parse/validation and ignore / downgrade / all-optional-fail behavior; `make fmt lint test` passes (race detector included).
- Verified end-to-end in `mixin/play`: Grafana shows the downgrade warning badge, and `ignore_error` returns partial results silently.

<img width="880" height="468" alt="image" src="https://github.com/user-attachments/assets/842dd055-2fa1-422b-a5cc-908504980793" />